### PR TITLE
Add CI workflow for running vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    uses: jill64/.github/.github/workflows/run-vitest.yml@main


### PR DESCRIPTION
This pull request adds a CI workflow for running vitest. The workflow is triggered on push and includes a job that uses the jill64/.github/.github/workflows/run-vitest.yml@main action. This will help ensure that vitest is run automatically and consistently on every push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Continuous Integration (CI) workflow that triggers on push events, enhancing the overall code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->